### PR TITLE
Convert pkg info to pkg -N info

### DIFF
--- a/lib/freebsd/sudo.sh
+++ b/lib/freebsd/sudo.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if pkg info | grep -q sudo; then
+if pkg -N info | grep -q sudo; then
 			VZVOL_SU_CMD="sudo"
 		else
 			VZVOL_SU_CMD="su - root -c"

--- a/lib/freebsd/vzvol_pkgcheck.sh
+++ b/lib/freebsd/vzvol_pkgcheck.sh
@@ -4,13 +4,13 @@ vzvol_pkg_check_freebsd(){
 		echo "Warning. You have selected an FS type supplied by a port. Now checking to see if the port is installed."
 		echo "Please note that unsupported FSes may exhibit unexpected behavior!"
 		if [ "${FSTYPE}" = "ext2" -o "${FSTYPE}" = "ext3" -o "${FSTYPE}" = "ext4" ]; then
-			pkg info | grep -q e2fsprogs
+			pkg -N info | grep -q e2fsprogs
 			if [ ! $? = 0 ]; then
 				echo "Error! You need to install sysutils/e2fsprogs first!"
 				return 1
 			fi
 		elif [ "${FSTYPE}" = "xfs" ]; then
-			pkg info | grep -q xfsprogs
+			pkg -N info | grep -q xfsprogs
 			if [ ! $? = 0 ]; then
 				echo "Error! You need to install sysutils/xfsprogs first!"
 				return 1

--- a/lib/shared/vzvol_getargz.sh
+++ b/lib/shared/vzvol_getargz.sh
@@ -86,7 +86,7 @@ vzvol_getargz() {
 				shift
 			;;
 			-p)
-				if pkg info | grep -vq pv; then
+				if pkg -N info | grep -vq pv; then
 					echo "Error! You need to install sysutils/pv first, or don't use -p"
 					return 1
 				fi


### PR DESCRIPTION
prevent bootstrapping pkg on a clean system.