### PR TITLE
Feature/remove internal sudo

### DIFF
--- a/bin/vzvol
+++ b/bin/vzvol
@@ -10,6 +10,7 @@ NO_CREATE=NO
 VOLTYPE=NULL
 vzvol_libdir=/usr/local/lib/vzvol/lib
 vzvol_gitdir=$( find ./ -name "vzvol" | grep bin | sed 's/.\{10\}$//' )
+ZUSER=NULL
 
 
 if [ ! "$(whoami)" = 'root' ]; then

--- a/bin/vzvol
+++ b/bin/vzvol
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-ZUSER=$( whoami )
 SIZE=10G
 VOLNAME=DIE
 FSTYPE=DIE
@@ -11,6 +10,12 @@ NO_CREATE=NO
 VOLTYPE=NULL
 vzvol_libdir=/usr/local/lib/vzvol/lib
 vzvol_gitdir=$( find ./ -name "vzvol" | grep bin | sed 's/.\{10\}$//' )
+
+
+if [ ! "$(whoami)" = 'root' ]; then
+	echo "Error. Please run vzvol as root or with sudo, and specify the user to set permissions for with -u or --user"
+	exit 1
+fi
 
 if [ -f ./vzvol ]; then
 	vzvol_libdir=../lib

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ However, to enable the use of certain functions, some additional packages are re
 - The -p flag requires the installation of sysutils/pv. This port is not needed if you don't use -p
 - XFS filesystem support requires the installation of sysutils/xfsprogs
 - ext2, ext3, and ext4 require the installation of sysutils/e2fsprogs
-- vzvol now relies on sudo internally on FreeBSD. Eventually, setting zvol permissions process will be altered and this removed.
+- vzvol no longer requires sudo, however now, it must either be run as root, or with sudo.
 
 By default, on FreeBSD, these options are enabled. They can be disabled if installing
 fron ports (once it's accepted).
@@ -73,8 +73,9 @@ Example: --size 10G | -s 1024M
 Defaults to 10G if nothing specified.
 
 -u | --user
+MANDATORY OPTION!!
 Sets the user under which we grant permissions for the zvol.
-Defaults to your username if nothing is specified.
+No longer defaults to your username, and is a mandatory option.
 
 -v | --volume
 MANDATORY OPTION!!

--- a/lib/freebsd/sudo.sh
+++ b/lib/freebsd/sudo.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-VZVOL_SU_CMD="sudo"

--- a/lib/freebsd/vzvol_import.sh
+++ b/lib/freebsd/vzvol_import.sh
@@ -22,7 +22,7 @@ vzvol_import_img() {
 	case "$line" in
 		y)
 			echo "Beginning import..."
-			"$VZVOL_SU_CMD" zfs set custom:fs=imported "${ZROOT}/${VOLNAME}"
+			zfs set custom:fs=imported "${ZROOT}/${VOLNAME}"
 			eval "$VZVOL_IMPORT_CMD"
 		;;
 		*)

--- a/lib/linux/sudo.sh
+++ b/lib/linux/sudo.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-VZVOL_SU_CMD="sudo"

--- a/lib/linux/vzvol_import.sh
+++ b/lib/linux/vzvol_import.sh
@@ -22,7 +22,7 @@ vzvol_import_img() {
 	case "$line" in
 		y)
 			echo "Beginning import..."
-			"$VZVOL_SU_CMD" zfs set custom:fs=imported "${ZROOT}/${VOLNAME}"
+			zfs set custom:fs=imported "${ZROOT}/${VOLNAME}"
 			eval "$VZVOL_IMPORT_CMD"
 		;;
 		*)

--- a/lib/shared/vzvol_create.sh
+++ b/lib/shared/vzvol_create.sh
@@ -2,11 +2,7 @@
 zvol_create() {
 	errorfunc='zvol_create'
 	if [ ! -e /dev/zvol/"${ZROOT}/${VOLNAME}" ]; then
-		if [ "${ZUSER}" = root ]; then
-			zfs create -V "${SIZE}" "${ZROOT}/${VOLNAME}"
-		else
-			"${VZVOL_SU_CMD}" zfs create -V "${SIZE}" "${ZROOT}/${VOLNAME}"
-		fi
+		zfs create -V "${SIZE}" "${ZROOT}/${VOLNAME}"
 	fi
 	ZVOL_NAME=/dev/zvol/"${ZROOT}/${VOLNAME}"
 	sleep 5

--- a/lib/shared/vzvol_delete.sh
+++ b/lib/shared/vzvol_delete.sh
@@ -9,7 +9,7 @@ vzvol_delete() {
 	case "$line" in
 		y)
 			echo "Deleting ${DELETE_ME}"
-			"$VZVOL_SU_CMD" zfs destroy "${DELETE_ME}"
+			zfs destroy "${DELETE_ME}"
 			if [ -f "${DELETE_VMDK}" ]; then
 				rm -f "${DELETE_VMDK}"
 			fi

--- a/lib/shared/vzvol_fs_type.sh
+++ b/lib/shared/vzvol_fs_type.sh
@@ -13,7 +13,7 @@ zvol_fs_type() {
 			return 1
 		;;
 	esac
-	"$VZVOL_SU_CMD" zfs set custom:fs="${FSTYPE}" "${FORMAT_ME}"
+	zfs set custom:fs="${FSTYPE}" "${FORMAT_ME}"
 	case "${FSTYPE}" in
 		zfs)
 			zvol_create_fs_zfs

--- a/lib/shared/vzvol_permissions.sh
+++ b/lib/shared/vzvol_permissions.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 vzvol_permissions() {
-	if [ "${ZUSER}" = root ]; then
-		chown "${ZUSER}" "${ZVOL_NAME}"
-		( echo "own	zvol/${ZROOT}/${VOLNAME}	${ZUSER}:operator" | tee -a /etc/devfs.conf ) > /dev/null 2>&1
-	else
-		"$VZVOL_SU_CMD" chown "${ZUSER}" "${ZVOL_NAME}"
-		( echo "own	zvol/${ZROOT}/${VOLNAME}	${ZUSER}:operator" | "$VZVOL_SU_CMD" tee -a /etc/devfs.conf ) > /dev/null 2>&1
-	fi
-	"$VZVOL_SU_CMD" zfs set custom:fs=none "${ZROOT}/${VOLNAME}"
+	
+	chown "${ZUSER}" "${ZVOL_NAME}"
+	( echo "own	zvol/${ZROOT}/${VOLNAME}	${ZUSER}:operator" | tee -a /etc/devfs.conf ) > /dev/null 2>&1
+
+	zfs set custom:fs=none "${ZROOT}/${VOLNAME}"
 	if [ ! "${FSTYPE}" = DIE ]; then
 		zvol_fs_type || return 1
 	fi

--- a/lib/shared/vzvol_showhelp.sh
+++ b/lib/shared/vzvol_showhelp.sh
@@ -26,8 +26,9 @@ Example: --size 10G | -s 1024M
 Defaults to 10G if nothing specified.
 
 -u | --user
+MANDATORY OPTION!!
 Sets the user under which we grant permissions for the zvol.
-Defaults to your username if nothing is specified.
+No longer defaults to your username, and is a mandatory option.
 
 -v | --volume
 MANDATORY OPTION!!

--- a/lib/shared/zvol_check.sh
+++ b/lib/shared/zvol_check.sh
@@ -5,6 +5,10 @@ zvol_check() {
 		echo "Please provide a zvol name. See --help for more information."
 		return 1
 	fi
+	if [ "${ZUSER}" = 'NULL' ]; then
+		echo "Please provide a user for vzvol to set permissions on your zvol. See --help for more information. Use --user to set this."
+		return 1
+	fi
 	if [ "${VOLTYPE}" = 'NULL' ]; then
 		echo "Error. Type not selected. See --help for more information."
 		echo "You need to select your type with -t or --type."


### PR DESCRIPTION
vzvol no longer does permissions funkiness for you. Run it as root or under sudo. It's basically a sysutil after all.
I should probably move the check after getargz so you can run vzvol --list without sudo but... that'll come in a later patch.